### PR TITLE
refactor: expose package modules and fix analysis import

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
-# swospam0418-Transformer-for-Etch-with-XAI
+# Transformer for Etch with XAI
+
+This project demonstrates an encoder-only Transformer for predicting plasma
+etching profiles from recipe step parameters.  The repository is organised
+into a small package called `etch` consisting of several independent
+modules:
+
+- `data_processing.py` – read Excel workbooks, standardise columns and build
+  PyTorch datasets.
+- `model.py` – definition of the Transformer network used for prediction.
+- `trainer.py` – training loop with validation and R² tracking.
+- `analysis.py` – helper functions for evaluating a trained model.
+- `predictor.py` – simple search utilities to find recipes that match a target
+  profile.
+- `sensitivity.py` – minimal tools for inspecting parameter influence.
+
+The package exposes these utilities via ``import etch``.  A minimal example
+that trains a model and runs a prediction is provided in ``main.py``:
+
+```bash
+python main.py path/to/data.xlsx --epochs 20 --batch-size 16
+```
+
+The code is intended as a clean starting point for further experimentation and
+analysis of plasma etching processes.

--- a/etch/__init__.py
+++ b/etch/__init__.py
@@ -1,0 +1,26 @@
+"""Core package exposing data processing, model, training and analysis utilities."""
+
+from .data_processing import (
+    read_merge_sheets,
+    EtchDataProcessor,
+    EtchDataset,
+    collate_fn,
+)
+from .model import EtchTransformer
+from .trainer import ModelTrainer
+from .analysis import single_recipe_predict, evaluate_predictions
+from .predictor import ForwardPredictor
+from .sensitivity import SensitivityAnalyzer
+
+__all__ = [
+    "read_merge_sheets",
+    "EtchDataProcessor",
+    "EtchDataset",
+    "collate_fn",
+    "EtchTransformer",
+    "ModelTrainer",
+    "single_recipe_predict",
+    "evaluate_predictions",
+    "ForwardPredictor",
+    "SensitivityAnalyzer",
+]

--- a/etch/analysis.py
+++ b/etch/analysis.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
+
 import numpy as np
 import matplotlib.pyplot as plt
+import torch
 from torch.utils.data import DataLoader
 from sklearn.metrics import r2_score
-
-from .data_processing import SingleEtchDataset, collate_fn_single
 
 
 def single_recipe_predict(model, seq, processor, device):


### PR DESCRIPTION
## Summary
- document project structure and usage in README
- expose core utilities through package `__init__`
- fix missing torch import in analysis module

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python main.py --help`


------
https://chatgpt.com/codex/tasks/task_e_689b4b26a5908328932dacf45408e6ea