### PR TITLE
Forward positional and parameter masks through training and utilities

### DIFF
--- a/etch/trainer.py
+++ b/etch/trainer.py
@@ -36,8 +36,10 @@ class ModelTrainer:
             for batch in train_loader:
                 optimizer.zero_grad()
                 out = self.model(batch["step_seq"].to(self.device),
+                                 batch["pos_seq"].to(self.device),
                                  batch["param_seq"].to(self.device),
-                                 batch["mask"].to(self.device))
+                                 batch["mask"].to(self.device),
+                                 batch["param_mask"].to(self.device))
                 tgt = batch["profile"].to(self.device)
                 loss = criterion(out, tgt)
                 loss.backward()
@@ -54,8 +56,10 @@ class ModelTrainer:
             with torch.no_grad():
                 for batch in val_loader:
                     out = self.model(batch["step_seq"].to(self.device),
+                                     batch["pos_seq"].to(self.device),
                                      batch["param_seq"].to(self.device),
-                                     batch["mask"].to(self.device))
+                                     batch["mask"].to(self.device),
+                                     batch["param_mask"].to(self.device))
                     tgt = batch["profile"].to(self.device)
                     loss = criterion(out, tgt)
                     val_loss += loss.item()


### PR DESCRIPTION
## Summary
- Pass `pos_seq` and `param_mask` through the training and validation loops.
- Extend analysis helpers and predictor to construct and use the new variable-parameter sequence format.
- Update sensitivity analysis to handle per-step parameter positions and masks.

## Testing
- `python -m py_compile etch/trainer.py etch/analysis.py etch/predictor.py etch/sensitivity.py`


------
https://chatgpt.com/codex/tasks/task_e_689b568ecae883288e899ca99d556379